### PR TITLE
Update build-debian.sh

### DIFF
--- a/build-debian.sh
+++ b/build-debian.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 ACSOPATCH_VER=6.3
 KERNEL_VER=6.3
-sudo apt install build-essential libncurses5-dev fakeroot xz-utils libelf-dev liblz4-tool unzip flex bison
+sudo apt install build-essential libncurses5-dev fakeroot xz-utils libelf-dev liblz4-tool \
+  unzip flex bison bc debhelper rsync libssl-dev:native
 wget -N https://raw.githubusercontent.com/benbaker76/linux-acs-override/main/6.3/acso.patch
 wget -N https://github.com/torvalds/linux/archive/refs/tags/v$KERNEL_VER.zip
 unzip -o v$KERNEL_VER.zip


### PR DESCRIPTION
Fixed the missing requirement, specifically `unzip`, so that the system can actually unzip the kernel source to build. `unzip` is not a guaranteed package historically.